### PR TITLE
Fix for _comreply method names

### DIFF
--- a/lib/MooseX/App/Plugin/BashCompletion/Command.pm
+++ b/lib/MooseX/App/Plugin/BashCompletion/Command.pm
@@ -56,7 +56,7 @@ _${prefix}_macc_help() {
 EOT
  
     while (my ($c, $o) = each %command_map) {
-        $syntax .= "_${prefix}_macc_$c() {\n    _compreply \"";
+        $syntax .= "_${prefix}_macc_$c() {\n    _${prefix}_compreply \"";
         $syntax .= join(" ", @$o);
         $syntax .= "\"\n}\n\n";
     }


### PR DESCRIPTION
I noticed the prefix was missing from the _comreply methods that the bash autocomplete generated.

Thanks,
Steve
