### PR TITLE
Use the SYNOPSIS as the usage text

### DIFF
--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -2,7 +2,7 @@
 
 # t/01_basic.t - Basic tests
 
-use Test::Most tests => 20+1;
+use Test::Most tests => 20+2;
 use Test::NoWarnings;
 
 use lib 't/testlib';
@@ -73,3 +73,15 @@ use Test01;
     --help --usage -?  Prints this usage information. [Flag]",'Options body is set');
     #print $test04;
 }
+
+subtest "usage via SYNOPSIS for command" => sub {
+    plan tests => 5;
+
+    local @ARGV = qw(command_b --help);
+    my $test04 = Test01->new_with_command;
+    isa_ok($test04,'MooseX::App::Message::Envelope');
+    is($test04->blocks->[0]->header,"usage:",'Usage is set');
+    like $test04->blocks->[0]->body => qr/test01 command_b yadah/, "Usage body set";
+    is($test04->blocks->[1]->header,"description:",'Description is set');
+    is($test04->blocks->[2]->header,"options:",'Options header is set');
+};

--- a/t/testlib/Test01/CommandB.pm
+++ b/t/testlib/Test01/CommandB.pm
@@ -19,6 +19,10 @@ sub run {
 
 Test01::CommandB - Test class command B for test 01
 
+=head1 SYNOPSIS
+
+    $ test01 command_b yadah
+
 =head1 DESCRIPTION
 
 Some description of B<command B>


### PR DESCRIPTION
The default usage message is fine, unless the command is
expected to take arguments, in which case there is no
easy way to pass that information.  This patch looks in
the command class file to see if there's a SYNOPSIS,
and if there is one, use that as the usage text.

Note: since this is Xmas Eve, I only hacked a dirty proof
of concept. If you like the idea, that patch should be cleaned up
before it's fully merged in.
