### PR TITLE
Add explicit dependency on GLD 0.091

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,6 +22,10 @@ requires        'Config::Any'                   => 0;
 requires        'String::CamelCase'             => 0;
 requires        'List::Util'                    => 0;
 requires        'Pod::Elemental'                => 0;
+# Although MooseX::App doesn't depend on Getopt::Long::Descriptive directly,
+# some tests rely on the particular error message "Mandatory parameter '...'
+# missing". This sentence was changed in v0.091.
+requires        'Getopt::Long::Descriptive'     => '0.091';
 
 recommends      'Term::ANSIColor'               => 0;
 recommends      'File::HomeDir'                 => 0;


### PR DESCRIPTION
Hi Maros

I made this change when trying to fix a build failure on my machine with recent versions of MooseX::App. Hope it's useful ...

git commit message:
Although MooseX::App doesn't depend on Getopt::Long::Descriptive
directly, some of the tests rely on the error message "Mandatory
parameter '...' missing" (t/05_extended.t and t/07_single.t). This error
message was only introduced in GLD v0.091. I noticed this when I
couldn't build MooseX::App on my machine, where GLD was still at v0.090.

Best regards
Edward
