### PR TITLE
patch tests to work with G::L::D v0.090 or earlier [ Alternative to previous pull request ]

### DIFF
--- a/t/05_extended.t
+++ b/t/05_extended.t
@@ -66,7 +66,7 @@ subtest 'All options available & no description' => sub {
 
 subtest 'Test wrapper script error' => sub {
     my $output = `$^X $FindBin::Bin/example/test03.pl some`;
-    like($output,qr/Mandatory parameter 'another' missing/,'Output is ok');
+    like($output,qr/Required option missing: another|Mandatory parameter 'another' missing/,'Output is ok');
 };
 
 subtest 'Test wrapper script encoding' => sub {

--- a/t/07_single.t
+++ b/t/07_single.t
@@ -13,7 +13,7 @@ subtest 'Single command' => sub {
     local @ARGV = qw();
     my $test05 = Test05->new_with_options;
     isa_ok($test05,'MooseX::App::Message::Envelope');
-    is($test05->blocks->[0]->header,"Mandatory parameter 'another_option' missing ","Check for error message");
+    like($test05->blocks->[0]->header,qr/^(Required option missing: another_option|Mandatory parameter 'another_option' missing )$/,"Check for error message");
 };
 
 subtest 'Single command' => sub {


### PR DESCRIPTION
Hi Maros

I have found another workaround to MooseX::App not installing on platforms with Getopt::Long::Descriptive v0.090 or earlier. This commit just patches the test instead of introducing an extra dependency. Maybe you like this solution better than the other one.

Regards
Edward

---git commit messag
The particular error message "Mandatory parameter '...' missing" has
changed in Getopt::Long::Descriptive between versions 0.090 and 0.091.
This commit patches MooseX::App's tests to allow for both versions of
the error message, allowing installs on platforms with a version of
G::L::D inferior to 0.091. Note that MooseX::App does not depend on
G::L::D directly.
