### PR TITLE
Silence experimental::smartmatch warnings

### DIFF
--- a/lib/MooseX/App/Exporter.pm
+++ b/lib/MooseX/App/Exporter.pm
@@ -10,6 +10,7 @@ use warnings;
 use Moose::Exporter;
 use MooseX::App::Utils;
 use MooseX::App::ParsedArgv;
+no if $] >= 5.018000, warnings => qw(experimental::smartmatch);
 
 our %PLUGIN_SPEC;
 

--- a/lib/MooseX/App/Message/BlockColor.pm
+++ b/lib/MooseX/App/Message/BlockColor.pm
@@ -8,6 +8,7 @@ use utf8;
 use namespace::autoclean;
 use Moose;
 extends qw(MooseX::App::Message::Block);
+no if $] >= 5.018000, warnings => qw(experimental::smartmatch);
 
 use Term::ANSIColor qw();
 use IO::Interactive qw(is_interactive);

--- a/lib/MooseX/App/Meta/Role/Class/Base.pm
+++ b/lib/MooseX/App/Meta/Role/Class/Base.pm
@@ -12,6 +12,7 @@ use MooseX::App::Utils;
 use Path::Class;
 use Module::Pluggable::Object;
 use List::Util qw(max);
+no if $] >= 5.018000, warnings => qw(experimental::smartmatch);
 
 has 'app_messageclass' => (
     is          => 'rw',

--- a/lib/MooseX/App/ParsedArgv.pm
+++ b/lib/MooseX/App/ParsedArgv.pm
@@ -9,6 +9,7 @@ use Moose;
 
 use Encode qw(decode);
 use MooseX::App::ParsedArgv::Element;
+no if $] >= 5.018000, warnings => qw(experimental::smartmatch);
 
 my $SINGLETON;
 

--- a/lib/MooseX/App/ParsedArgv/Element.pm
+++ b/lib/MooseX/App/ParsedArgv/Element.pm
@@ -6,6 +6,7 @@ use 5.010;
 use utf8;
 
 use Moose;
+no if $] >= 5.018000, warnings => qw(experimental::smartmatch);
 
 has 'key' => (
     is              => 'ro',

--- a/lib/MooseX/App/Utils.pm
+++ b/lib/MooseX/App/Utils.pm
@@ -4,6 +4,7 @@ use 5.010;
 use utf8;
 use strict;
 use warnings;
+no if $] >= 5.018000, warnings => qw/ experimental::smartmatch /;
 
 use List::Util qw(max);
 


### PR DESCRIPTION
We know smartmatch is experimental, and we accept the risk of
using it. This fixes spurious test failures like RT #84986.
