### PR TITLE
[FIX] test uses recommened module

### DIFF
--- a/t/testlib/Test02.pm
+++ b/t/testlib/Test02.pm
@@ -1,7 +1,7 @@
 package Test02;
 
 use Moose;
-use MooseX::App (qw(BashCompletion Version Man), ($ENV{HARNESS} ? ():qw(ConfigHome Color Typo Term) ));
+use MooseX::App (qw(BashCompletion Version Man), ($ENV{HARNESS_ACTIVE} ? ():qw(ConfigHome Color Typo Term) ));
 
 our $VERSION = 1.01;
 


### PR DESCRIPTION
Text::WagnerFischer is only recommended, not required. The unit test
shows how to use it (as an example) but tries not to run the code that
uses Text::WagnerFischer when executed as part of the unit tests. For
this the test accidently checks $ENV{HARNESS} when the correct variable
is called $ENV{HARNESS_ACTIVE}. Fixed.