### PR TITLE
Fix for app_prefer_commandline

### DIFF
--- a/lib/MooseX/App.pm
+++ b/lib/MooseX/App.pm
@@ -17,7 +17,7 @@ use Moose::Exporter;
 use Scalar::Util qw(blessed);
 
 my ($IMPORT,$UNIMPORT,$INIT_META) = Moose::Exporter->build_import_methods(
-    with_meta           => [ qw(app_usage app_description app_namespace app_base app_fuzzy app_command_name app_command_register app_strict option parameter app_permute) ],
+    with_meta           => [ qw(app_usage app_description app_namespace app_base app_fuzzy app_command_name app_command_register app_strict app_prefer_commandline option parameter app_permute) ],
     also                => [ 'Moose' ],
     as_is               => [ 'new_with_command' ],
     install             => [ 'unimport','init_meta' ],

--- a/t/testlib/Test01.pm
+++ b/t/testlib/Test01.pm
@@ -4,6 +4,7 @@ use Moose;
 use MooseX::App qw(Config);
 
 app_strict 1;
+app_prefer_commandline 0;
 
 app_description "Huissasa";
 


### PR DESCRIPTION
app_prefer_commandline was missing from build_import_methods.
It was thus not available to be called in a  MooseX::App base class.