### PR TITLE
bash completion: app names with dashes create invalid variable names

### DIFF
--- a/lib/MooseX/App/Plugin/BashCompletion/Command.pm
+++ b/lib/MooseX/App/Plugin/BashCompletion/Command.pm
@@ -26,7 +26,7 @@ sub bash_completion {
     $mday               = sprintf('%02i',$mday);
     $mon                = sprintf('%02i',$mon+1);
     
-    $prefix             =~ tr/./_/;
+    $prefix             =~ tr/.-/_/;
     
     foreach my $command (keys %{$commands}) {
         my $command_class = $commands->{$command};


### PR DESCRIPTION
```
bash: my-app-name_COMMANDS=help bash_completion zsh_completion: command not found
```
