### PR TITLE
Option Order/Position in Usage Message

### DIFF
--- a/lib/MooseX/App/Meta/Role/Class/Base.pm
+++ b/lib/MooseX/App/Meta/Role/Class/Base.pm
@@ -645,7 +645,8 @@ sub command_usage_attributes {
     }
     
     return (sort { 
-        $a->cmd_position <=> $b->cmd_position
+        $a->cmd_position <=> $b->cmd_position ||
+        $a->cmd_usage_name cmp $b->cmd_usage_name
     } @return);
 }
 
@@ -656,12 +657,7 @@ sub command_usage_options {
     $metaclass ||= $self;
     
     my @options;
-    foreach my $attribute (
-        sort {
-            $a->cmd_position <=> $b->cmd_position ||
-            $a->cmd_usage_name cmp $b->cmd_usage_name
-        } $self->command_usage_attributes($metaclass,[qw(option proto)])
-    ) {
+    foreach my $attribute ($self->command_usage_attributes($metaclass,[qw(option proto)])) {
         push(@options,[
             $attribute->cmd_usage_name(),
             $attribute->cmd_usage_description()

--- a/t/01_basic.t
+++ b/t/01_basic.t
@@ -34,8 +34,8 @@ subtest 'Wrong command' => sub {
     01_basic.t help
     01_basic.t <command> --help",'Usage body set');
     is($test03->blocks->[3]->header,"global options:",'Global options set');
-    is($test03->blocks->[3]->body,"    --config              Path to command config file
-    --global              test [Required; Integer; Important!]
+    is($test03->blocks->[3]->body,"    --global              test [Required; Integer; Important!]
+    --config              Path to command config file
     --help -h --usage -?  Prints this usage information. [Flag]",'Global options body set');
     is($test03->blocks->[4]->header,"available commands:",'Available commands set');
     is($test03->blocks->[4]->body,"    command_a   Command A!
@@ -61,12 +61,12 @@ subtest 'Help for command' => sub {
     * bullet3
     Cras eget mi nisi. In hac habitasse platea dictumst.",'Description body set');
     is($test04->blocks->[2]->header,"options:",'Options header is set');
-    is($test04->blocks->[2]->body,"    --command_local1      some docs about the long texts that seem to occur
+    is($test04->blocks->[2]->body,"    --global              test [Required; Integer; Important!]
+    --command_local1      some docs about the long texts that seem to occur
                           randomly [Integer; Env: LOCAL1; Important]
     --command_local2      Verylongwordwithoutwhitespacestotestiftextformating
                           worksproperly [Env: LOCAL2]
     --config              Path to command config file
-    --global              test [Required; Integer; Important!]
     --help -h --usage -?  Prints this usage information. [Flag]",'Options body is set');
 };
 

--- a/t/05_extended.t
+++ b/t/05_extended.t
@@ -58,12 +58,12 @@ subtest 'All options available & no description' => sub {
     my $test04 = Test03->new_with_command;
     isa_ok($test04,'MooseX::App::Message::Envelope');
     is($test04->blocks->[2]->header,'options:','No description');
-    is($test04->blocks->[2]->body,"    --another             [Required; Not important]
-    --global_option       Enable this to do fancy stuff [Flag]
-    --help -h --usage -?  Prints this usage information. [Flag]
-    --list                [Multiple]
+    is($test04->blocks->[2]->body,"    --global_option       Enable this to do fancy stuff [Flag]
     --roleattr            [Role]
-    --some_option         Very important option!","Message ok");
+    --some_option         Very important option!
+    --another             [Required; Not important]
+    --list                [Multiple]
+    --help -h --usage -?  Prints this usage information. [Flag]","Message ok");
 };
 
 # Not working on cpan testers


### PR DESCRIPTION
According to the documentation for MooseX::App, the ordering of options / parameters in the usage message is something that can be altered by specifying the 'cmd_position' attribute property, however it does not appear to be functional for options.

I am not sure if this was intended and the documentation is just overstating the feature, but this patch enables the feature for options.