### PR TITLE
Deterministic bash_completion files

### DIFF
--- a/lib/MooseX/App/Plugin/BashCompletion/Command.pm
+++ b/lib/MooseX/App/Plugin/BashCompletion/Command.pm
@@ -17,7 +17,7 @@ sub bash_completion {
     my %command_map;
     my $app_meta        = $app->meta;
     my $commands        = $app_meta->app_commands;
-    my @commands_to_complete = grep { $_ ne 'bash_completion' } keys %{$commands};
+    my @commands_to_complete = grep { $_ ne 'bash_completion' } sort keys %{$commands};
     my $command_list    = join (' ', @commands_to_complete);
     my $package         = __PACKAGE__;
     my $prefix          = $app_meta->app_base;
@@ -59,7 +59,7 @@ _${prefix}_macc_help() {
 
 EOT
 
-    foreach my $command (keys %command_map) {
+    foreach my $command (sort keys %command_map) {
         $syntax .= "_${prefix}_macc_${command}() {\n    _${prefix}_compreply \"";
         #$syntax .= join(" ", @{$data->{parameters}});
         $syntax .= join(" ", @{$command_map{$command}->{options}});


### PR DESCRIPTION
Hi,

   We pre-generate bash_completion files and version them. Seeing differences between runs of bash_completion is useful for us, since it makes visualizing changes much easier.

   Please consider merging this change and releasing a new MooseX::App.

Best Regards,

pplu