### PR TITLE
Add ConfigXDG plugin

### DIFF
--- a/lib/MooseX/App/Plugin/ConfigXDG.pm
+++ b/lib/MooseX/App/Plugin/ConfigXDG.pm
@@ -1,0 +1,48 @@
+package MooseX::App::Plugin::ConfigXDG;
+
+
+use 5.010;
+use utf8;
+
+use namespace::autoclean;
+use Moose::Role;
+with qw(MooseX::App::Plugin::Config);
+
+sub plugin_metaroles {
+    my ($self, $class) = @_;
+
+    return {
+        class => [
+            'MooseX::App::Plugin::Config::Meta::Class',
+            'MooseX::App::Plugin::ConfigXDG::Meta::Class'
+        ]
+    };
+}
+
+1;
+
+__END__
+
+=encoding utf8
+
+=head1 NAME
+
+MooseX::App::Plugin::ConfigXDG - Config files in XDG config directories
+
+=head1 SYNOPSIS
+
+In your base class:
+
+ package MyApp;
+ use MooseX::App qw(ConfigXDG);
+
+=head1 DESCRIPTION
+
+Works just like L<MooseX::App::Plugin::Config>, but assumes that the config
+file always resides in the user's XDG config directory.  By default, this is
+C<< $HOME/.config/${app-base}/config.(yml|xml|ini|...) >>.
+
+You can override the XDG config base (from C<< $HOME/.config >>) with the
+environmental variable C<XDG_CONFIG_HOME>.
+
+=cut

--- a/lib/MooseX/App/Plugin/ConfigXDG/Meta/Class.pm
+++ b/lib/MooseX/App/Plugin/ConfigXDG/Meta/Class.pm
@@ -1,0 +1,34 @@
+package MooseX::App::Plugin::ConfigXDG::Meta::Class;
+
+use 5.010;
+use utf8;
+
+use namespace::autoclean;
+use Moose::Role;
+
+use File::HomeDir ();
+use File::Spec ();
+
+around proto_config => sub {
+    my $orig = shift;
+    my ($self,$command_class,$result,$errors) = @_;
+
+    unless (defined $result->{config}) {
+        my $xdg_config_home = $ENV{XDG_CONFIG_HOME}
+            || File::Spec->catdir( File::HomeDir->my_home, '.config' );
+
+        my $config_dir = File::Spec->catdir($xdg_config_home, $self->app_base);
+
+        foreach my $extension (Config::Any->extensions) {
+            my $check_file = File::Spec->catfile($config_dir, 'config.'.$extension);
+            if (-e $check_file) {
+                $result->{config} = $check_file;
+                last;
+            }
+        }
+    }
+
+    return $self->$orig($command_class,$result,$errors);
+};
+
+1;

--- a/t/00_load.t
+++ b/t/00_load.t
@@ -2,7 +2,7 @@
 
 # t/00_load.t - check module loading and create testing directory
 
-use Test::Most tests => 43;
+use Test::Most tests => 45;
 
 use_ok( 'MooseX::App' );
 use_ok( 'MooseX::App::ParsedArgv' );
@@ -70,6 +70,8 @@ SKIP :{
         Class::Load::load_class('File::HomeDir');
         use_ok( 'MooseX::App::Plugin::ConfigHome' );
         use_ok( 'MooseX::App::Plugin::ConfigHome::Meta::Class');
+        use_ok( 'MooseX::App::Plugin::ConfigXDG' );
+        use_ok( 'MooseX::App::Plugin::ConfigXDG::Meta::Class');
     };
     unless ($ok) {
         skip "File::HomeDir is not installed",2;


### PR DESCRIPTION
This is similiar to the ConfigHome plugin, but uses the XDG Base
Directory specification to look for the config file.  By default this
will be $HOME/.config/${app-base}/config.*