### PR TITLE
Fix for `Uninitialized Value` Issue

### DIFF
--- a/lib/MooseX/App/Plugin/Term/Meta/Attribute.pm
+++ b/lib/MooseX/App/Plugin/Term/Meta/Attribute.pm
@@ -230,7 +230,7 @@ sub cmd_term_read_string {
                 print "\b".substr $return,$cursor; # print
                 print " ".(("\b") x (length($return) - $cursor + 1)); # cursor
             } else { # Character
-                if ($_ <= 31) { # ignore controll chars
+                if ($key_code <= 31) { # ignore controll chars
                     print "\a";
                     next KEY_STRING;
                 } elsif (defined $allowed


### PR DESCRIPTION
I encountered the following issue when converting one of my `MooseX::App` options to use the `MooseX::App::Plugin::Term` functionality:

> user (Optional, a string) :
> Use of uninitialized value $_ in numeric le (<=) at MooseX/App/Plugin/Term/Meta/Attribute.pm line 233.
> Use of uninitialized value $_ in numeric le (<=) at MooseX/App/Plugin/Term/Meta/Attribute.pm line 233.
> Use of uninitialized value $_ in numeric le (<=) at MooseX/App/Plugin/Term/Meta/Attribute.pm line 233.

This change seems to correct that issue with no side effects so far.