### PR TITLE
sort options in bash_completion

### DIFF
--- a/lib/MooseX/App/Plugin/BashCompletion/Command.pm
+++ b/lib/MooseX/App/Plugin/BashCompletion/Command.pm
@@ -62,7 +62,7 @@ EOT
     foreach my $command (sort keys %command_map) {
         $syntax .= "_${prefix}_macc_${command}() {\n    _${prefix}_compreply \"";
         #$syntax .= join(" ", @{$data->{parameters}});
-        $syntax .= join(" ", @{$command_map{$command}->{options}});
+        $syntax .= join(" ", sort @{$command_map{$command}->{options}});
         $syntax .= "\"\n}\n\n";
     }
 


### PR DESCRIPTION
without this patch the output of "<command> bash_completion" differs between
each call. This breaks reproducible builds like in Debian or SUSE, because,
even without code changes, the content of a built package (deb or rpm) which
include a file containing the bash_completion differs on each build.
See also https://wiki.debian.org/ReproducibleBuilds.

This patch sorts the options before generating the output of bash_completion
to generate reproducible results.