### PR TITLE
fix testing for Moose 2.2014

### DIFF
--- a/t/05_extended.t
+++ b/t/05_extended.t
@@ -241,7 +241,9 @@ subtest 'Test enum error message' => sub {
     MooseX::App::ParsedArgv->new(argv => [qw(somecommand --another hase hh h ggg)]);
     my $test18 = Test03->new_with_command();
     isa_ok($test18,'MooseX::App::Message::Envelope');
-    is($test18->blocks->[0]->body,"Value must be one of these values: aaa, bbb, ccc, ddd, eee, fff (not 'ggg')","Check enum error message");
+    like($test18->blocks->[0]->body,
+        qr{(Value must be one of these values: aaa, bbb, ccc, ddd, eee, fff \(not 'ggg'\)|Validation failed for '__ANON__' with value "?ggg"?. Value must be equal to "aaa", "bbb", "ccc", "ddd", "eee", or "fff".)},
+        "Check enum error message");
 };
 
 subtest 'Test empty multi' => sub {


### PR DESCRIPTION
Without this patch the test suite breaks with the new Moose version (2.2014).

This patch should be able to handle the old and the new error messages.

fixes issue #62