### PR TITLE
Remove given, when, and smartmatch operators

### DIFF
--- a/lib/MooseX/App/Message/BlockColor.pm
+++ b/lib/MooseX/App/Message/BlockColor.pm
@@ -8,7 +8,6 @@ use utf8;
 use namespace::autoclean;
 use Moose;
 extends qw(MooseX::App::Message::Block);
-no if $] >= 5.018000, warnings => qw(experimental::smartmatch);
 
 use Term::ANSIColor qw();
 use IO::Interactive qw(is_interactive);
@@ -24,17 +23,16 @@ sub stringify {
 
     my $header_color;
     my $body_color;
-    given ($self->type) {
-        when('error') {
-            $header_color = 'bright_red bold';
-            $body_color = 'bright_red';
-        }
-        when('default') {
-            $header_color = 'bold';
-        }
-        default {
-            $header_color = $_;
-        }
+    my $type = $self->type;
+    if($type eq 'error') {
+        $header_color = 'bright_red bold';
+        $body_color = 'bright_red';
+    }
+    elsif($type eq 'default') {
+        $header_color = 'bold';
+    }
+    else {
+        $header_color = $type;
     }
 
     my $message = '';

--- a/lib/MooseX/App/Meta/Role/Class/Base.pm
+++ b/lib/MooseX/App/Meta/Role/Class/Base.pm
@@ -13,7 +13,6 @@ use Moose::Role;
 use MooseX::App::Utils;
 use Module::Pluggable::Object;
 use File::Basename qw();
-no if $] >= 5.018000, warnings => qw(experimental::smartmatch);
 
 has 'app_messageclass' => (
     is          => 'rw',
@@ -357,32 +356,30 @@ sub command_parse_options {
             }
 
             # Process matches
-            given (scalar @{$match_attributes}) {
-                # No match
-                when(0) {}
-                # One match
-                when(1) {
-                    my $attribute = $match_attributes->[0];
-                    $option->consume();
-                    $match->{$attribute->name} ||= [];
-                    push(@{$match->{$attribute->name}},$option);
-                }
-                # Multiple matches
-                default {
-                    $option->consume();
-                    push(@errors,
-                        $self->command_message(
-                            header          => "Ambiguous option '".$option->key."'", # LOCALIZE
-                            type            => "error",
-                            body            => "Could be\n".MooseX::App::Utils::format_list( # LOCALIZE
-                                map { [ $_ ] }
-                                sort
-                                map { $_->cmd_name_primary }
-                                @{$match_attributes}
-                            ),
-                        )
-                    );
-                }
+            # No match
+            if(@{$match_attributes} == 0) {}
+            # One match
+            elsif(@{$match_attributes} == 1) {
+                my $attribute = $match_attributes->[0];
+                $option->consume();
+                $match->{$attribute->name} ||= [];
+                push(@{$match->{$attribute->name}},$option);
+            }
+            # Multiple matches
+            else {
+                $option->consume();
+                push(@errors,
+                    $self->command_message(
+                        header          => "Ambiguous option '".$option->key."'", # LOCALIZE
+                        type            => "error",
+                        body            => "Could be\n".MooseX::App::Utils::format_list( # LOCALIZE
+                            map { [ $_ ] }
+                            sort
+                            map { $_->cmd_name_primary }
+                            @{$match_attributes}
+                        ),
+                    )
+                );
             }
         }
     }
@@ -569,30 +566,28 @@ sub command_find {
             $parsed_argv->shift_argv;
             return $candidate;
         }
-        given (scalar @{$candidate}) {
-            when (0) {
-                next;
-            }
-            when (1) {
-                if ($self->app_fuzzy) {
-                    $parsed_argv->shift_argv;
-                    return $candidate->[0];
-                } else {
-                    return $self->command_message(
-                        header          => "Unknown command '$command'", # LOCALIZE
-                        type            => "error",
-                        body            => "Did you mean '".$candidate->[0]."'?", # LOCALIZE
-                    );
-                }
-            }
-            default {
+        if (@{$candidate} == 0) {
+            next;
+        }
+        elsif (@{$candidate} == 1) {
+            if ($self->app_fuzzy) {
+                $parsed_argv->shift_argv;
+                return $candidate->[0];
+            } else {
                 return $self->command_message(
-                    header          => "Ambiguous command '$command'", # LOCALIZE
+                    header          => "Unknown command '$command'", # LOCALIZE
                     type            => "error",
-                    body            => "Which command did you mean?\n". # LOCALIZE
-                        MooseX::App::Utils::format_list(map { [ $_ ] } sort @{$candidate}),
+                    body            => "Did you mean '".$candidate->[0]."'?", # LOCALIZE
                 );
             }
+        }
+        else {
+            return $self->command_message(
+                header          => "Ambiguous command '$command'", # LOCALIZE
+                type            => "error",
+                body            => "Which command did you mean?\n". # LOCALIZE
+                    MooseX::App::Utils::format_list(map { [ $_ ] } sort @{$candidate}),
+            );
         }
     }
 
@@ -725,6 +720,9 @@ sub command_usage_attributes {
 
     $metaclass ||= $self;
     $types ||= [qw(option proto)];
+    if ('' eq ref $types) {
+        $types = [$types];
+    }
 
     unless ($metaclass->does_role('MooseX::App::Role::Common')) {
         Moose->throw_error('Class '.$metaclass->name.' is not a proper MooseX::App::Command class. You either need to use MooseX::App::Command or exclude this class via app_exclude')
@@ -737,8 +735,7 @@ sub command_usage_attributes {
             && $attribute->has_cmd_type;
 
         next
-            unless $types eq 'all'
-            || $attribute->cmd_type ~~ $types;
+            unless map {($attribute->cmd_type eq $_ or 'all' eq $_) ? (1) : ()} @$types;
 
         push(@return,$attribute);
     }

--- a/lib/MooseX/App/Plugin/Term/Meta/Attribute.pm
+++ b/lib/MooseX/App/Plugin/Term/Meta/Attribute.pm
@@ -8,8 +8,6 @@ use 5.010;
 use namespace::autoclean;
 use Moose::Role;
 
-no if $] >= 5.018000, warnings => qw(experimental::smartmatch);
-
 use Term::ReadKey;
 
 has 'cmd_term' => (
@@ -106,7 +104,7 @@ sub cmd_term_read_string {
         if (! $history_disable
             && defined $entry
             && $entry !~ m/^\s*$/
-            && ! ($entry ~~ \@history)) {
+            && ! (map {$entry eq $_ ? (1) : ()} @history)) {
             push(@history,$entry);
         }
     };
@@ -167,55 +165,53 @@ sub cmd_term_read_string {
                     $escape .= $code;
                 }
                 if (defined $escape) {
-                    given ($escape) {
-                        when ('[D') { # Cursor left
-                            if ($cursor > 0) {
-                                print "\b";
-                                $cursor--;
-                            }
+                    if ($escape eq '[D') { # Cursor left
+                        if ($cursor > 0) {
+                            print "\b";
+                            $cursor--;
                         }
-                        when ($escape eq '[C') { # Cursor right
-                            if ($cursor < length($return)) {
-                                print substr $return,$cursor,1;
-                                $cursor++;
-                            }
-                        }
-                        when ($escape eq '[A') { # Cursor up
-                            $history_add->($return);
-                            print "\b" x $cursor;
-                            print " " x length($return);
-                            print "\b" x length($return);
-
-                            $history_index ++
-                                if defined $history[$history_index]
-                                && $history[$history_index] eq $return;
-                            $history_index = 0
-                                unless defined $history[$history_index];
-
-                            $return = $history[$history_index];
-                            $cursor = length($return);
-                            print $return;
-                            $history_index++;
-                        }
-                        when ($escape eq '[3~') { # Del
-                            if ($cursor != length($return)) {
-                                substr $return,$cursor,1,'';
-                                print substr $return,$cursor;
-                                print " ".(("\b") x (length($return) - $cursor + 1));
-                            }
-                        }
-                        when ($escape eq 'OH') { # Pos 1
-                            print (("\b") x $cursor);
-                            $cursor = 0;
-                        }
-                        when ($escape eq 'OF') { # End
-                            print substr $return,$cursor;
-                            $cursor = length($return);
-                        }
-                        #default {
-                        #    print $escape;
-                        #}
                     }
+                    elsif ($escape eq '[C') { # Cursor right
+                        if ($cursor < length($return)) {
+                            print substr $return,$cursor,1;
+                            $cursor++;
+                        }
+                    }
+                    elsif ($escape eq '[A') { # Cursor up
+                        $history_add->($return);
+                        print "\b" x $cursor;
+                        print " " x length($return);
+                        print "\b" x length($return);
+
+                        $history_index ++
+                            if defined $history[$history_index]
+                            && $history[$history_index] eq $return;
+                        $history_index = 0
+                            unless defined $history[$history_index];
+
+                        $return = $history[$history_index];
+                        $cursor = length($return);
+                        print $return;
+                        $history_index++;
+                    }
+                    elsif ($escape eq '[3~') { # Del
+                        if ($cursor != length($return)) {
+                            substr $return,$cursor,1,'';
+                            print substr $return,$cursor;
+                            print " ".(("\b") x (length($return) - $cursor + 1));
+                        }
+                    }
+                    elsif ($escape eq 'OH') { # Pos 1
+                        print (("\b") x $cursor);
+                        $cursor = 0;
+                    }
+                    elsif ($escape eq 'OF') { # End
+                        print substr $return,$cursor;
+                        $cursor = length($return);
+                    }
+                    #else {
+                    #    print $escape;
+                    #}
                 } else {
                     $history_add->($return);
                     next TRY_STRING;


### PR DESCRIPTION
Perl 5.38.0 deprecated smartmatch. New warning messages caused tests to fail:

~~~~
    given is deprecated at /builddir/build/BUILD/MooseX-App-1.42/blib/lib/MooseX/App/Meta/Role/Class/Base.pm line 572.
    when is deprecated at /builddir/build/BUILD/MooseX-App-1.42/blib/lib/MooseX/App/Meta/Role/Class/Base.pm line 573.
    when is deprecated at /builddir/build/BUILD/MooseX-App-1.42/blib/lib/MooseX/App/Meta/Role/Class/Base.pm line 576.
    Smartmatch is deprecated at /builddir/build/BUILD/MooseX-App-1.42/blib/lib/MooseX/App/Meta/Role/Class/Base.pm line 741.

    #   Failed test 'no warnings'
    #   at /usr/share/perl5/Test/Builder.pm line 193.
    # There were 24 warning(s)
    #     Previous test 0 ''
    #     given is deprecated at /builddir/build/BUILD/MooseX-App-1.42/blib/lib/MooseX/App/Utils.pm line 237.
    #  at /builddir/build/BUILD/MooseX-App-1.42/blib/lib/MooseX/App/Utils.pm line 237.
    # 	require MooseX/App/Utils.pm called at /builddir/build/BUILD/MooseX-App-1.42/blib/lib/MooseX/App/Exporter.pm line 11
    # 	MooseX::App::Exporter::BEGIN() called at /builddir/build/BUILD/MooseX-App-1.42/blib/lib/MooseX/App/Exporter.pm line 11
    # 	eval {...} called at /builddir/build/BUILD/MooseX-App-1.42/blib/lib/MooseX/App/Exporter.pm line 11
    # 	require MooseX/App/Exporter.pm called at /builddir/build/BUILD/MooseX-App-1.42/blib/lib/MooseX/App.pm line 14
    # 	MooseX::App::BEGIN() called at /builddir/build/BUILD/MooseX-App-1.42/blib/lib/MooseX/App.pm line 14
    # 	eval {...} called at /builddir/build/BUILD/MooseX-App-1.42/blib/lib/MooseX/App.pm line 14
    # 	require MooseX/App.pm called at t/testlib/Test01.pm line 4
    # 	Test01::BEGIN() called at t/testlib/Test01.pm line 4
    # 	eval {...} called at t/testlib/Test01.pm line 4
    # 	require Test01.pm called at t/01_basic.t line 11
    # 	main::BEGIN() called at t/01_basic.t line 11
    # 	eval {...} called at t/01_basic.t line 11
    #
    # ----------
~~~~

Since smartmatch will be removed from Perl 5.42, this patch fixes the test failures by replacing given, when, and ~~ operator with a plain, old Perl.

<https://github.com/maros/MooseX-App/issues/69>