### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/lib/MooseX/App/Plugin/BashCompletion/Command.pm
+++ b/lib/MooseX/App/Plugin/BashCompletion/Command.pm
@@ -22,7 +22,7 @@ sub bash_completion {
     my $package         = __PACKAGE__;
     my $prefix          = $app_meta->app_base;
 
-    my ($sec,$min,$hour,$mday,$mon,$year) = localtime(time);
+    my ($sec,$min,$hour,$mday,$mon,$year) = gmtime($ENV{SOURCE_DATE_EPOCH} || time);
     $year               += 1900;
     $mday               = sprintf('%02i',$mday);
     $mon                = sprintf('%02i',$mon+1);


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH` to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Also use UTC/gmtime to be independent of timezone.