### PR TITLE
Fix bashcompletion with subcommands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ cover_db/
 /MYMETA.*
 nytprof/
 nytprof.out
+# vim temp files
+.*.sw?

--- a/lib/MooseX/App/Plugin/BashCompletion/Command.pm
+++ b/lib/MooseX/App/Plugin/BashCompletion/Command.pm
@@ -17,8 +17,10 @@ sub bash_completion {
     my %command_map;
     my $app_meta        = $app->meta;
     my $commands        = $app_meta->app_commands;
-    my @commands_to_complete = grep { $_ ne 'bash_completion' } sort keys %{$commands};
-    my $command_list    = join (' ', @commands_to_complete);
+    my @filtered_cmds   = grep { $_ ne 'bash_completion' } keys %{$commands};
+    my %unique_cmds     = map { my @c = split ' ', $_; ($c[0], 1); } @filtered_cmds;
+    my @cmds2complete   = sort(@filtered_cmds);
+    my $command_list    = join (' ', sort(keys(%unique_cmds)));
     my $package         = __PACKAGE__;
     my $prefix          = $app_meta->app_base;
 
@@ -29,14 +31,17 @@ sub bash_completion {
 
     $prefix             =~ tr/./_/;
 
-    foreach my $command (@commands_to_complete) {
+    foreach my $command (@cmds2complete) {
         my $command_class = $commands->{$command};
         Class::Load::load_class($command_class);
-        #my @parameters = $app_meta->command_usage_attributes($command_class->meta,'parameter');
-        my @options = $app_meta->command_usage_attributes($command_class->meta,[qw(option proto)]);
+	my @sub_map  = map { $_ =~ /^${command} (\w+)/; $1;  } sort(@filtered_cmds);
+	my @sub_cmds = grep { defined $_ } @sub_map;
+        my @options = $app_meta->command_usage_attributes(
+	                $command_class->meta,
+			[qw(option proto)],
+		      );
         $command_map{$command} = {
-            #parameters  => [ map { $_->is_required } @parameters ],
-            options     => [ map { $_->cmd_usage_name } @options ],
+            options => [@sub_cmds, sort(map { $_->cmd_usage_name } @options)],
         };
     }
 
@@ -60,9 +65,11 @@ _${prefix}_macc_help() {
 EOT
 
     foreach my $command (sort keys %command_map) {
-        $syntax .= "_${prefix}_macc_${command}() {\n    _${prefix}_compreply \"";
+        my $fn_suffix = $command;
+        $fn_suffix =~ s/ /_/g;
+        $syntax .= "_${prefix}_macc_${fn_suffix}() {\n    _${prefix}_compreply \"";
         #$syntax .= join(" ", @{$data->{parameters}});
-        $syntax .= join(" ", sort @{$command_map{$command}->{options}});
+        $syntax .= join(" ", @{$command_map{$command}->{options}});
         $syntax .= "\"\n}\n\n";
     }
 

--- a/t/08_plugin_various.t
+++ b/t/08_plugin_various.t
@@ -19,6 +19,10 @@ subtest 'Bash completion' => sub {
     like($bash_completion,qr/_test03_macc_somecommand\(\)\s\{/,'some_command present');
     like($bash_completion,qr/--global_option/,'global_option present');
     like($bash_completion,qr/--roleattr/,'roleattr present');
+    like($bash_completion,qr/_test03_macc_cmdwithsubcommands_subb/,'subcommand B present');
+    like($bash_completion,qr/_test03_macc_cmdwithsubcommands_subb/,'subcommand B present');
+    unlike($bash_completion,qr/_test03_macc_cmdwithsubcommands subb/,'subcommand B present');
+    unlike($bash_completion,qr/_test03_macc_cmdwithsubcommands subb/,'subcommand B present');
     unlike($bash_completion,qr/bash_completion/,'bash_completion is not included');
 };
 

--- a/t/testlib/Test03/CmdWithSubCommands/SubA.pm
+++ b/t/testlib/Test03/CmdWithSubCommands/SubA.pm
@@ -1,0 +1,14 @@
+package Test03::CmdWithSubCommands::SubA;
+
+use MooseX::App::Command;
+
+sub run {
+    my ($self) = @_;
+    use Data::Dumper;
+    {
+      local $Data::Dumper::Maxdepth = 2;
+      warn __FILE__.':line'.__LINE__.':'.Dumper($self);
+    }
+}
+
+1;

--- a/t/testlib/Test03/CmdWithSubCommands/SubB.pm
+++ b/t/testlib/Test03/CmdWithSubCommands/SubB.pm
@@ -1,0 +1,14 @@
+package Test03::CmdWithSubCommands::SubB;
+
+use MooseX::App::Command;
+
+sub run {
+    my ($self) = @_;
+    use Data::Dumper;
+    {
+      local $Data::Dumper::Maxdepth = 2;
+      warn __FILE__.':line'.__LINE__.':'.Dumper($self);
+    }
+}
+
+1;


### PR DESCRIPTION
Fixes: https://github.com/maros/MooseX-App/issues/72

**Improvements/Fixes:**

* Filter out duplicate entries from `_.*_COMMANDS="..."`
* Do not add subcommands to `_.*_COMMANDS="..."`
* add subcommands at the beginning of `_.*_macc_command` options list
* use `_.*_command_subcommand() { ... }` instead of `_.*_command subcommand() { ... }`